### PR TITLE
remove ActionController::RackDelegation

### DIFF
--- a/lib/devise/failure_app.rb
+++ b/lib/devise/failure_app.rb
@@ -6,7 +6,6 @@ module Devise
   # page based on current scope and mapping. If no scope is given, redirect
   # to the default_url.
   class FailureApp < ActionController::Metal
-    include ActionController::RackDelegation
     include ActionController::UrlFor
     include ActionController::Redirecting
 


### PR DESCRIPTION
Thanks for this rails 5 branch, 
according to rails/rails@d474387
the RackDelegation has been deleted.

all tests passed.

thanks.
